### PR TITLE
Add citable frontmatter option for blog posts

### DIFF
--- a/components/BlogHeader.tsx
+++ b/components/BlogHeader.tsx
@@ -9,6 +9,7 @@ export const frontmatterSchema = z.object({
 	title: z.string(),
 	publishedOn: z.string().date(),
 	updatedOn: z.string().date().optional(),
+	citable: z.boolean().optional(),
 });
 
 export const postSchema = frontmatterSchema.extend({
@@ -47,13 +48,17 @@ const BlogHeader: React.FC<{frontmatter: unknown; href: string}> = ({frontmatter
 			<Head>
 				<title>{`${parsed.title} - Adam Jones's Blog`}</title>
 				<link rel='alternate' type='application/rss+xml' title='RSS' href='../feed' />
-				<meta name='citation_title' content={parsed.title} />
-				<meta name='citation_author' content='Adam Jones' />
-				<meta name='citation_date' content={citationDate} />
-				<meta name='citation_online_date' content={citationDate} />
-				<meta name='citation_publication_date' content={citationDate} />
-				<meta name='citation_fulltext_html_url' content={`https://adamjones.me${href}`} />
-				<meta name='citation_fulltext_world_readable' content='' />
+				{parsed.citable && (
+					<>
+						<meta name='citation_title' content={parsed.title} />
+						<meta name='citation_author' content='Adam Jones' />
+						<meta name='citation_date' content={citationDate} />
+						<meta name='citation_online_date' content={citationDate} />
+						<meta name='citation_publication_date' content={citationDate} />
+						<meta name='citation_fulltext_html_url' content={`https://adamjones.me${href}`} />
+						<meta name='citation_fulltext_world_readable' content='' />
+					</>
+				)}
 			</Head>
 			<script
 				type='application/ld+json'

--- a/pages/blog/300k-ai-annotators.mdx
+++ b/pages/blog/300k-ai-annotators.mdx
@@ -1,6 +1,7 @@
 ---
 title: "300,000 people are directly creating training data for AI"
 publishedOn: "2025-04-21"
+citable: true
 ---
 
 As of April 2025, at least 300,000 people work directly on creating training data for AI systems. This is roughly comparable to a small island nation - between Barbados and Vanuatu.

--- a/pages/blog/ai-biorisk-paper.mdx
+++ b/pages/blog/ai-biorisk-paper.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Quantitative models of AI-driven bioterrorism and lab leak biorisk"
 publishedOn: "2025-06-25"
+citable: true
 ---
 
 import BarChart from '../../components/BarChart'

--- a/pages/blog/ai-model-thresholds.mdx
+++ b/pages/blog/ai-model-thresholds.mdx
@@ -1,6 +1,7 @@
 ---
 title: "AI Model Thresholds: How Governments Can Identify Frontier AI Systems"
 publishedOn: "2025-06-30"
+citable: true
 ---
 
 Strict regulations for every AI system would likely hinder innovation and overwhelm regulators. But doing nothing about [catastrophic risks](https://bluedot.org/blog/ai-risks) from frontier systems would be a mistake.

--- a/pages/blog/ai-oligarchies-arising.mdx
+++ b/pages/blog/ai-oligarchies-arising.mdx
@@ -1,6 +1,7 @@
 ---
 title: "How might AI-enabled oligarchies arise?"
 publishedOn: "2024-05-11"
+citable: true
 ---
 
 [Advanced AI systems](https://www.cold-takes.com/transformative-ai-timelines-part-1-of-4-what-kind-of-ai/#explosive-scientific-and-technological-advancement) pose [significant](https://www.lesswrong.com/posts/pRkFkzwKZ2zfa3R6H/without-specific-countermeasures-the-easiest-path-to) [risks](https://aisafetyfundamentals.com/blog/ai-risks/). Some of the most important and neglected work to be done on these risks is preventing irreparably bad futures.[^1]

--- a/pages/blog/ai-oligarchies-preventing.mdx
+++ b/pages/blog/ai-oligarchies-preventing.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Preventing AI oligarchies: important, neglected and tractable work"
 publishedOn: "2024-05-12"
+citable: true
 ---
 
 In [a previous article](../ai-oligarchies-arising/), I set out what I mean by AI-enabled oligarchies, why they could lead to an irreparably bad future, and how they might arise. To recap, an AI-enabled oligarchy is where AI systems concentrate power in the hands of a few entities that are then able to effectively control the world. This would be particularly hard to recover from because AI systems might enable a regime to create such a power imbalance it’s hard to topple, and AI systems don’t become old and die in the way humans do.

--- a/pages/blog/ai-regulator-toolbox.mdx
+++ b/pages/blog/ai-regulator-toolbox.mdx
@@ -1,6 +1,7 @@
 ---
-title: "The AI regulator’s toolbox: A list of concrete AI governance practices"
+title: "The AI regulator's toolbox: A list of concrete AI governance practices"
 publishedOn: "2024-08-10"
+citable: true
 ---
 
 This article explains concrete AI governance practices people are exploring as of August 2024.

--- a/pages/blog/ai-safety-txt.mdx
+++ b/pages/blog/ai-safety-txt.mdx
@@ -1,6 +1,7 @@
 ---
 title: "ai-safety.txt: Making AI vulnerability reporting easy"
 publishedOn: "2024-03-17"
+citable: true
 ---
 
 import Details from '../../components/Details';

--- a/pages/blog/ai-vulnerability-reporting.mdx
+++ b/pages/blog/ai-vulnerability-reporting.mdx
@@ -1,6 +1,7 @@
 ---
 title: How are AI companies doing with their voluntary commitments on vulnerability reporting?
 publishedOn: "2024-02-20"
+citable: true
 ---
 
 import Details from '../../components/Details';

--- a/pages/blog/hitl-complacency-prevention.mdx
+++ b/pages/blog/hitl-complacency-prevention.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Preventing overreliance: The case for deliberate AI errors in human-in-the-loop systems"
 publishedOn: "2024-07-08"
+citable: true
 ---
 
 import Details from '../../components/Details';

--- a/pages/blog/hitl-intro.mdx
+++ b/pages/blog/hitl-intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Why having a human-in-the-loop doesn't solve everything"
 publishedOn: "2024-07-07"
+citable: true
 ---
 
 import Details from '../../components/Details';

--- a/pages/blog/oh-good.mdx
+++ b/pages/blog/oh-good.mdx
@@ -1,6 +1,7 @@
 ---
 title: "OHGOOD: A coordination body for compute governance"
 publishedOn: "2024-03-03"
+citable: true
 ---
 
 import Details from '../../components/Details';

--- a/pages/blog/openai-regulated-by-nis.mdx
+++ b/pages/blog/openai-regulated-by-nis.mdx
@@ -1,6 +1,7 @@
 ---
-title: "OpenAI’s cybersecurity is probably regulated by NIS Regulations"
+title: "OpenAI's cybersecurity is probably regulated by NIS Regulations"
 publishedOn: "2024-10-25"
+citable: true
 ---
 
 The EU and UK's [Network and Information Systems (NIS) Regulations](https://digital-strategy.ec.europa.eu/en/policies/nis2-directive) aim to improve the cybersecurity of essential services and important digital providers. They set requirements around network security, information system security, physical security, incident handling, business continuity and security auditing.

--- a/pages/blog/problems-with-compute-thresholds-ai-regulation.mdx
+++ b/pages/blog/problems-with-compute-thresholds-ai-regulation.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Overcoming problems with compute thresholds for AI regulation"
 publishedOn: "2025-06-30"
+citable: true
 ---
 
 A threshold is a well-defined boundary to define which AI systems are covered by regulations. Compute thresholds focus on the amount of computer processing power used to train the system - usually measured in FLOP (floating point operations). There are many [different types of thresholds that could be used](/blog/ai-model-thresholds).

--- a/pages/blog/right-of-appeal-problems.mdx
+++ b/pages/blog/right-of-appeal-problems.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Addressing digital harms: a right of appeal is not sufficient"
 publishedOn: "2024-07-15"
+citable: true
 ---
 
 In the privacy and AI governance space, people often suggest that a right to appeal or object could resolve many problems.

--- a/pages/blog/rough-alignment-plan-early-2025.mdx
+++ b/pages/blog/rough-alignment-plan-early-2025.mdx
@@ -1,6 +1,7 @@
 ---
 title: "A rough plan for AI alignment assuming short timelines"
 publishedOn: "2025-03-31"
+citable: true
 ---
 
 This is my rough plan for how I would plan to [intent align](https://aisafetyfundamentals.com/blog/what-is-ai-alignment/) powerful AI systems if we're getting them in the next 2-5 years. This only covers intent alignment, and not [other problems in AI safety](https://adamjones.me/blog/alignment-is-not-all-you-need/).

--- a/pages/blog/uk-agi-plan-2025.mdx
+++ b/pages/blog/uk-agi-plan-2025.mdx
@@ -1,6 +1,7 @@
 ---
 title: "What should the UK be doing to make AGI go well?"
 publishedOn: "2025-08-15"
+citable: true
 ---
 
 We could end up in an AGI race between the US and China. These race dynamics incentivize cutting corners on safety, and having AGI controlled by a single nation (even a democratic one) concentrates unprecedented power in one place.


### PR DESCRIPTION
## Summary

- Added `citable` boolean to blog post frontmatter schema
- Citation meta tags (citation_title, citation_author, citation_date, etc.) now only render when `citable: true`
- Added `citable: true` to 17 academic-style blog posts covering AI governance, policy analysis, and technical research