### PR TITLE
Fix unreadable text in AI vs Human speed demo in dark mode

### DIFF
--- a/pages/blog/what-is-agi.mdx
+++ b/pages/blog/what-is-agi.mdx
@@ -282,7 +282,7 @@ PawRide is a game-changing startup that's poised to revolutionize the way dogs g
   const humanProgress = humanText.length / fullText.length * 100;
 
   return (
-    <div className='p-4 border rounded-lg border-gray-200 bg-gray-50 my-6 not-prose'>
+    <div className='p-4 border rounded-lg border-gray-200 bg-gray-50 text-gray-900 my-6 not-prose'>
       <div className='flex justify-between items-center mb-4'>
         <h3 className='text-lg font-bold text-gray-800'>AI vs Human Output Speed</h3>
         <button


### PR DESCRIPTION
The `not-prose` container inherits `prose-invert`'s light text color from the parent, making the `<pre>` content (which has no explicit text color) nearly invisible on its white background in dark mode.

Adding `text-gray-900` to the container overrides the inherited color so all text in the light-background box stays readable.