### PR TITLE
Fix Turbopack build failure after Next.js 16 upgrade

### DIFF
--- a/lib/recma-href.mjs
+++ b/lib/recma-href.mjs
@@ -1,0 +1,33 @@
+import path from 'node:path';
+
+export default function recmaHref() {
+	return (ast, vfile) => {
+		const pathFromRoot = path.relative(vfile.cwd, path.join(vfile.dirname, vfile.stem));
+		const rootRelativeUrl = `/${pathFromRoot.startsWith('pages/') ? pathFromRoot.slice('pages/'.length) : pathFromRoot}/`;
+
+		ast.body.push({
+			type: 'ExpressionStatement',
+			expression: {
+				type: 'AssignmentExpression',
+				operator: '=',
+				left: {
+					type: 'MemberExpression',
+					object: {
+						type: 'Identifier',
+						name: 'MDXContent',
+					},
+					property: {
+						type: 'Identifier',
+						name: 'href',
+					},
+					computed: false,
+					optional: false,
+				},
+				right: {
+					type: 'Literal',
+					value: rootRelativeUrl,
+				},
+			},
+		});
+	};
+}

--- a/lib/rehype-hoverable-footnotes.mjs
+++ b/lib/rehype-hoverable-footnotes.mjs
@@ -1,0 +1,69 @@
+import {visit} from 'unist-util-visit';
+
+export default function rehypeAddHoverableFootnotes() {
+	return (tree) => {
+		// STEP 1: Extract footnote contents
+		// Map from id to footnote content (array of elements)
+		const footnoteMap = new Map();
+		visit(tree, 'element', (node) => {
+			if (node.tagName === 'li' && node.properties?.id?.toString().startsWith('user-content-fn-')) {
+				const footnoteId = node.properties.id;
+				const relevantChildren = node.children
+					// Remove empty nodes
+					.filter((c) => c.type !== 'text' || c.value !== '\n')
+					// Remove backreference links
+					.filter((c) => 'properties' in c && c.properties?.dataFootnoteBackref === undefined)
+					.map((c) => ({
+						...c,
+						children: 'children' in c ? c.children.filter((cc) => !('properties' in cc) || cc.properties?.dataFootnoteBackref === undefined) : undefined,
+					}));
+
+				footnoteMap.set(footnoteId, relevantChildren);
+			}
+		});
+
+		// STEP 2: Inject footnotes inline
+		visit(tree, 'element', (node) => {
+			const footnoteChildren = node.children.filter((c) => c.type === 'element' && c.tagName === 'sup' && c.children?.[0].type === 'element' && c.children[0].properties.dataFootnoteRef);
+			for (const footnoteNode of footnoteChildren) {
+				const footnoteId = footnoteNode.children[0].properties.href?.toString().slice(1);
+				const relevantChildren = footnoteMap.get(footnoteId);
+
+				// Set the parent to relative, so the footnote can be positioned relative to it with the right width
+				node.properties ??= {};
+				node.properties.className = `${node.properties.className?.toString() ?? ''} relative`.trim();
+
+				// React doesn't like nesting elements (like p's, ul's, etc.) inside of p's, because technically this is invalid HTML
+				// This causes hydration errors when we insert our footnote if it contains these elements
+				// Our hacky solution is to change the outer p's to spans with custom formatting (yuck)
+				// NB: this still breaks for headings, but footnotes are rare in headings so I haven't bothered fixing this
+				if (node.tagName === 'p') {
+					node.tagName = 'span';
+					node.properties.className += ' block my-5';
+				}
+
+				// Update the footnote tooltip trigger (anchor element) to have a wider hitbox, so it's easier to use and you can hover from the trigger to the tooltip itself
+				// We also wrap the inner content in a span so the outline still is in the right place though
+				footnoteNode.children[0].properties.className = 'p-4 -m-4 group outline-none';
+				footnoteNode.children[0].children = [{
+					type: 'element',
+					tagName: 'span',
+					properties: {
+						className: 'group-focus-visible:outline-2 outline-blue-600 rounded-xs',
+					},
+					children: footnoteNode.children[0].children,
+				}];
+
+				// Create the footnote tooltip
+				node.children.splice(node.children.indexOf(footnoteNode) + 1, 0, {
+					type: 'element',
+					tagName: 'span',
+					properties: {
+						className: 'absolute block !-mt-2 bg-white dark:bg-stone-800 border w-full border-stone-300 dark:border-stone-600 rounded-sm shadow-sm px-3 text-xs z-10 transition-all origin-top-left invisible scale-0 [sup:hover_+_&]:visible [sup:focus-within_+_&]:visible hover:visible focus-within:visible [sup:hover_+_&]:scale-100 [sup:focus-within_+_&]:scale-100 hover:scale-100 focus-within:scale-100',
+					},
+					children: relevantChildren,
+				});
+			}
+		});
+	};
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,144 +1,44 @@
 import type {NextConfig} from 'next';
-import type hast from 'hast';
-import type {Plugin} from 'unified';
-import type {Program} from 'estree';
+import nextMDX from '@next/mdx';
 import path from 'node:path';
 
-const rehypeAddHoverableFootnotes = () => {
-	return async (tree: hast.Root) => {
-		const {visit} = await import('unist-util-visit');
+// Turbopack serializes loader options, so plugins must be referenced as
+// resolvable strings rather than function references. The mdx-js-loader
+// handles require.resolve + dynamic import at runtime.
+const projectRoot = process.cwd();
 
-		// STEP 1: Extract footnote contents
-		// Map from id to footnote content (array of elements)
-		const footnoteMap = new Map();
-		visit(tree, 'element', (node) => {
-			if (node.tagName === 'li' && node.properties?.id?.toString().startsWith('user-content-fn-')) {
-				const footnoteId = node.properties.id;
-				const relevantChildren = node.children
-					// Remove empty nodes
-					.filter((c) => c.type !== 'text' || c.value !== '\n')
-					// Remove backreference links
-					.filter((c) => 'properties' in c && c.properties?.dataFootnoteBackref === undefined)
-					.map((c) => ({
-						...c,
-						children: 'children' in c ? c.children.filter((cc) => !('properties' in cc) || cc.properties?.dataFootnoteBackref === undefined) : undefined,
-					}));
+const withMDX = nextMDX({
+	extension: /\.mdx?$/,
+	options: {
+		remarkPlugins: [
+			'remark-frontmatter',
+			'remark-gfm',
+		],
+		rehypePlugins: [
+			'rehype-slug',
+			'@stefanprobst/rehype-extract-toc',
+			'@stefanprobst/rehype-extract-toc/mdx',
+			path.join(projectRoot, 'lib/rehype-hoverable-footnotes.mjs'),
+		],
+		recmaPlugins: [
+			'recma-mdx-displayname',
+			'recma-mdx-frontmatter',
+			path.join(projectRoot, 'lib/recma-href.mjs'),
+			'recma-nextjs-static-props',
+		],
+	},
+});
 
-				footnoteMap.set(footnoteId, relevantChildren);
-			}
-		});
-
-		// STEP 2: Inject footnotes inline
-		visit(tree, 'element', (node) => {
-			const footnoteChildren = node.children.filter((c) => c.type === 'element' && c.tagName === 'sup' && c.children?.[0].type === 'element' && c.children[0].properties.dataFootnoteRef) as (hast.Element & {children: [hast.Element]})[];
-			for (const footnoteNode of footnoteChildren) {
-				const footnoteId = footnoteNode.children[0].properties.href?.toString().slice(1);
-				const relevantChildren = footnoteMap.get(footnoteId);
-
-				// Set the parent to relative, so the footnote can be positioned relative to it with the right width
-				node.properties ??= {};
-				node.properties.className = `${node.properties.className?.toString() ?? ''} relative`.trim();
-
-				// React doesn't like nesting elements (like p's, ul's, etc.) inside of p's, because technically this is invalid HTML
-				// This causes hydration errors when we insert our footnote if it contains these elements
-				// Our hacky solution is to change the outer p's to spans with custom formatting (yuck)
-				// NB: this still breaks for headings, but footnotes are rare in headings so I haven't bothered fixing this
-				if (node.tagName === 'p') {
-					node.tagName = 'span';
-					node.properties.className += ' block my-5';
-				}
-
-				// Update the footnote tooltip trigger (anchor element) to have a wider hitbox, so it's easier to use and you can hover from the trigger to the tooltip itself
-				// We also wrap the inner content in a span so the outline still is in the right place though
-				footnoteNode.children[0].properties.className = 'p-4 -m-4 group outline-none';
-				footnoteNode.children[0].children = [{
-					type: 'element',
-					tagName: 'span',
-					properties: {
-						className: 'group-focus-visible:outline-2 outline-blue-600 rounded-xs',
-					},
-					children: footnoteNode.children[0].children,
-				}];
-
-				// Create the footnote tooltip
-				node.children.splice(node.children.indexOf(footnoteNode) + 1, 0, {
-					type: 'element',
-					tagName: 'span',
-					properties: {
-						className: 'absolute block !-mt-2 bg-white dark:bg-stone-800 border w-full border-stone-300 dark:border-stone-600 rounded-sm shadow-sm px-3 text-xs z-10 transition-all origin-top-left invisible scale-0 [sup:hover_+_&]:visible [sup:focus-within_+_&]:visible hover:visible focus-within:visible [sup:hover_+_&]:scale-100 [sup:focus-within_+_&]:scale-100 hover:scale-100 focus-within:scale-100',
-					},
-					children: relevantChildren,
-				});
-			}
-		});
-	};
+const nextConfig: NextConfig = {
+	output: 'export',
+	distDir: 'dist',
+	reactStrictMode: true,
+	images: {
+		unoptimized: true,
+	},
+	pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
+	trailingSlash: true,
+	devIndicators: false,
 };
 
-/** @type {import("unified")} */
-const recmaHref: Plugin<[], Program> = () => (ast, vfile) => {
-	const pathFromRoot = path.relative(vfile.cwd, path.join(vfile.dirname!, vfile.stem!));
-	const rootRelativeUrl = `/${pathFromRoot.startsWith('pages/') ? pathFromRoot.slice('pages/'.length) : pathFromRoot}/`;
-
-	ast.body.push({
-		type: 'ExpressionStatement',
-		expression: {
-			type: 'AssignmentExpression',
-			operator: '=',
-			left: {
-				type: 'MemberExpression',
-				object: {
-					type: 'Identifier',
-					name: 'MDXContent',
-				},
-				property: {
-					type: 'Identifier',
-					name: 'href',
-				},
-				computed: false,
-				optional: false,
-			},
-			right: {
-				type: 'Literal',
-				value: rootRelativeUrl,
-			},
-		},
-	});
-};
-
-export default async (): Promise<NextConfig> => {
-	const nextMDX = (await import('@next/mdx')).default;
-
-	const remarkFrontmatter = (await import('remark-frontmatter')).default;
-	const remarkGfm = (await import('remark-gfm')).default;
-
-	const rehypeSlug = (await import('rehype-slug')).default;
-	const rehypeExtractToc = (await import('@stefanprobst/rehype-extract-toc')).default;
-	const rehypeExtractTocExport = (await import('@stefanprobst/rehype-extract-toc/mdx')).default;
-
-	const recmaMdxDisplayname = (await import('recma-mdx-displayname')).default;
-	const recmaMdxFrontmatter = (await import('recma-mdx-frontmatter')).default;
-	const recmaNextjsStaticProps = (await import('recma-nextjs-static-props')).default;
-
-	const withMDX = nextMDX({
-		extension: /\.mdx?$/,
-		options: {
-			remarkPlugins: [remarkFrontmatter, remarkGfm],
-			rehypePlugins: [rehypeSlug, rehypeExtractToc, rehypeExtractTocExport, rehypeAddHoverableFootnotes],
-			recmaPlugins: [recmaMdxDisplayname, recmaMdxFrontmatter, recmaHref, recmaNextjsStaticProps],
-		},
-	});
-
-	const nextConfig: NextConfig = {
-		output: 'export',
-		distDir: 'dist',
-		reactStrictMode: true,
-		images: {
-			unoptimized: true,
-		},
-		pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
-		trailingSlash: true,
-		devIndicators: false,
-	};
-
-	return withMDX(nextConfig);
-};
+export default withMDX(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@mdx-js/loader": "^3.1.0",
-        "@next/mdx": "^15.1.3",
+        "@next/mdx": "^16.1.6",
         "@stefanprobst/rehype-extract-toc": "^3.0.0",
         "@tailwindcss/postcss": "^4.0.3",
         "@tailwindcss/typography": "^0.5.16",
@@ -803,9 +803,9 @@
       "license": "MIT"
     },
     "node_modules/@next/mdx": {
-      "version": "15.1.3",
-      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-15.1.3.tgz",
-      "integrity": "sha512-dvOQWYbvdztu9ubhSwQPTnIY5zUA8lorEtO1+f8kaba2nVjQSh3G16tfqY/8Ovw9T3kAJhxOZIbuWMpaeDIBAw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-16.1.6.tgz",
+      "integrity": "sha512-PT5JR4WPPYOls7WD6xEqUVVI9HDY8kY7XLQsNYB2lSZk5eJSXWu3ECtIYmfR0hZpx8Sg7BKZYKi2+u5OTSEx0w==",
       "license": "MIT",
       "dependencies": {
         "source-map": "^0.7.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@mdx-js/loader": "^3.1.0",
-    "@next/mdx": "^15.1.3",
+    "@next/mdx": "^16.1.6",
     "@stefanprobst/rehype-extract-toc": "^3.0.0",
     "@tailwindcss/postcss": "^4.0.3",
     "@tailwindcss/typography": "^0.5.16",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,9 +15,15 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
+    "jsx": "react-jsx",
+    "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Dependabot bumped `next` to 16.1.5 (#37) but left `@next/mdx` at 15.1.3. Next 16 defaults to Turbopack for builds, which broke CI in two ways:

1. `@next/mdx@15` writes to `experimental.turbo`, which is now invalid — Next 16 uses a top-level `turbopack` key instead
2. Turbopack serializes loader options, so function references in the MDX plugin arrays can't be passed through

The error surfaced as an unhelpful `Failed to write page endpoint /feedback — Expected process result to be a module, but it could not be processed`, but `/feedback` was just the first page alphabetically to hit the broken MDX rule.

**Fix:**
- Bump `@next/mdx` to `^16.1.6`
- Pass plugins as resolvable strings instead of imported function refs — `mdx-js-loader` imports them at runtime
- Extract the two inline custom plugins (`rehypeAddHoverableFootnotes`, `recmaHref`) to separate `.mjs` files so they can be referenced by path

`tsconfig.json` was auto-updated by Next to set `jsx: react-jsx`.