### PR TITLE
Fix broken internal links in blog RSS feed

### DIFF
--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -213,7 +213,7 @@ export function getSortedPostsData(): Post[] {
 		return {
 			...matterData,
 			href,
-			absoluteUrl: `https://adamjones.me/blog/${href.slice(2)}`,
+			absoluteUrl: `https://adamjones.me${href}`,
 			location: 'internal',
 		};
 	});


### PR DESCRIPTION
Internal blog posts computed their `absoluteUrl` as `https://adamjones.me/blog/${href.slice(2)}`, but `href` already starts with `/blog/`. The `slice(2)` stripped `/b` instead of just the leading slash, producing broken `https://adamjones.me/blog/log/<slug>/` URLs (404s) in the RSS feed — and in the JSON-LD structured data on the blog index.

Fixed by using `https://adamjones.me${href}`, matching the pattern already used correctly in `BlogHeader.tsx`. External post links were unaffected.

Closes #51