### PR TITLE
Add rel=code-repository link tag

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -8,6 +8,7 @@ const Document: React.FC = () => {
 			<Head>
 				<meta name='author' content='Adam Jones (domdomegg)' />
 				<link rel='icon' href='/favicon.ico' />
+				<link rel='code-repository' href='https://github.com/domdomegg/domdomegg.github.io' />
 				<meta name='darkreader-lock' />
 			</Head>
 			<body>


### PR DESCRIPTION
Adds a `<link rel="code-repository">` tag to the document head pointing at this GitHub repository, so tools and agents can discover the site's source code from the page HTML.

`code-repository` is listed in the [microformats existing-rel-values registry](https://microformats.org/wiki/existing-rel-values) under HTML5 link type extensions, making it a conforming rel value per the WHATWG HTML spec's extension mechanism.